### PR TITLE
sknobs_set_seed_flag should be clear in sknobs_close, support case user want clear sknobs_db and re-load new sknobs file. 

### DIFF
--- a/src/c/sknobs.c
+++ b/src/c/sknobs.c
@@ -1273,7 +1273,8 @@ void sknobs_close(void) {
   if (debug > 0) {
     printf("info: sknobs: close\n");
   }
-
+  // re-init seed_flag
+  sknobs_set_seed_flag = 0;
   // free up knobs list
   knob = sknob_list;
   while (knob) {


### PR DESCRIPTION
reset sknobs_set_seed_flag=0 when user call sknobs_close, support for case user want to clear sknobs_table