### PR TITLE
Fixed typemap call for perl's swig interface

### DIFF
--- a/src/perl/sknobs.i
+++ b/src/perl/sknobs.i
@@ -5,7 +5,7 @@
 #include "XSUB.h" 
 
 // This tells SWIG to treat char ** as a special case
-%typemap(perl5,in) char ** {
+%typemap(in) char ** {
   AV *tempav;
   I32 len;
   int i;
@@ -25,7 +25,7 @@
 };
 
 // This cleans up our char ** array after the function call
-%typemap(perl5,freearg) char ** {
+%typemap(freearg) char ** {
   free($1);
 }
 


### PR DESCRIPTION
typemap was using a deprecated syntax. That was turned into an error circa 2022. fixes #19 